### PR TITLE
Fix heading level in "Jupyter Notebook basics"

### DIFF
--- a/notebooks/Jupyter_notebook_basics.ipynb
+++ b/notebooks/Jupyter_notebook_basics.ipynb
@@ -16,7 +16,7 @@
     "\n",
     "Jupyter notebook enables you to share your code and the documentation of this code in a very effective way. \n",
     "\n",
-    "### Cells\n",
+    "## Cells\n",
     "\n",
     "A notebook is essentially a collection of cells. We shall be working with two types of cells. \n",
     "\n",
@@ -35,9 +35,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello world!\n"
+     ]
+    }
+   ],
    "source": [
     "# This cell contains code\n",
     "print('Hello world!')"
@@ -117,7 +125,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/notebooks/Jupyter_notebook_basics.ipynb
+++ b/notebooks/Jupyter_notebook_basics.ipynb
@@ -35,17 +35,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Hello world!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# This cell contains code\n",
     "print('Hello world!')"


### PR DESCRIPTION
We shouldn't jump from an h1 heading to h3.