### PR TITLE
Update tutorial and solutions for Dictionaries

### DIFF
--- a/notebooks/6 Dictionaries.ipynb
+++ b/notebooks/6 Dictionaries.ipynb
@@ -4,16 +4,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\n",
     "# 6. Dictionaries\n",
     "\n",
-    "Like a list, a dictionary is a data structure which can be used to collect multiple values. While the indices of lists consist of numbers which are assigned automatically, programmers need to define these indices themselves. The indices of dictionaries can be of any value type. \n",
+    "Like a list, a dictionary is a data structure which can be used to collect multiple values.\n",
+    "A dictionary is useful to keep related things together in a way that allows you to look them up later.\n",
+    "\n",
+    "We learned how we can look up values in a list by their index, which is always a number.\n",
+    "In a dictionary, we say that we use a *key*, not index, to look up the corresponding *value*.\n",
+    "Keys can be of any type, but you do need to specify them explicitly when you add an item to a dictionary.\n",
+    "You will see that keys are often strings, because it makes it easier to understand the code.\n",
     "\n",
     "## Creating a dictionary\n",
     "\n",
-    "A dictionary can be created using the `dict()` function. This function results in an empty dictionary. Elements can be added to the dictionary by using the bracket operator containing the index. The value associated with this index needs to be given after the assignment operator. Importantly, each of these indices must be unique. \n",
-    "\n",
-    "This data structure can used to store pairs of keys and values. "
+    "There are multiple ways to create a dictionary.\n",
+    "One way is to use the `dict()` function. This function results in an empty dictionary."
    ]
   },
   {
@@ -22,14 +26,51 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = dict()\n",
-    "\n",
-    "data['firstName'] = 'William'\n",
-    "data['lastName'] = 'Shakespeare'\n",
-    "data['yearOfBirth'] = 1564\n",
-    "\n",
-    "print( data['firstName'] + ' ' + data['lastName'] )\n",
-    "## This prints 'William Shakespeare'\n"
+    "shakespeare_dict = dict()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Values can be added to the dictionary by assigning them to the key in the dictionary.\n",
+    "We refer to such a key using the dictionary variable combined with square brackets containing the key.\n",
+    "The value to be associated with this key needs to be given after the assignment operator."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shakespeare_dict['first_name'] = 'William'\n",
+    "shakespeare_dict['last_name'] = 'Shakespeare'\n",
+    "shakespeare_dict['year_of_birth'] = 1564"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Referencing keys in a dictionary gives you their values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print( shakespeare_dict['first_name'] + ' ' + shakespeare_dict['last_name'] )\n",
+    "## This prints 'William Shakespeare'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Just like regular variables, you can overwrite values in dictionaries by assigning a different value to the key."
    ]
   },
   {
@@ -38,7 +79,14 @@
    "source": [
     "## Non-existing keys\n",
     "\n",
-    "As can be seen in the code above, the individual values in dictionaries can be accessed by using their indices. When you mention an index that does not actually exist, however, the code produces an error. It is evidently impossible to make use of an index which does not exist. To avoid such error messages, you can make use of the get() method. This method requires two values. Firstly, you need to mention the index of the element that you want to retrieve. Secondly, you have to provide a default value which should be returned when the index that was supplied does not exist. "
+    "As can be seen in the code above, the individual values in dictionaries can be accessed using their keys.\n",
+    "When you reference a key that does not actually exist in the dictionary, however, the code produces an error.\n",
+    "It is evidently impossible to retrieve a value for a key that does not exist.\n",
+    "\n",
+    "To avoid such error messages, you can make use of the `get()` method.\n",
+    "This method requires two values.\n",
+    "Firstly, you need to mention the key of the element that you want to retrieve.\n",
+    "Secondly, you have to provide a default value which should be returned when the key that was supplied does not exist. "
    ]
   },
   {
@@ -47,18 +95,32 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print( data.get( 'yearOfDeath' , 'NULL' ) )\n",
-    "# prints 'NULL' if the variable data['yearOfDeath'] has not been set yet.\n",
-    "\n",
-    "print( data.get( 'numberOfChildren' , 0 ) )\n",
-    "# prints 0 if the variable data['numberOfChildren'] has not been set yet."
+    "print( shakespeare_dict.get( 'year_of_death', 'NULL' ) )\n",
+    "# prints 'NULL' if the variable shakespeare_dict['year_of_death'] has not been set yet."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print( shakespeare_dict.get( 'number_of_children', 0 ) )\n",
+    "# prints 0 if the variable shakespeare_dict['number_of_children'] has not been set yet."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Instead of starting with an empty list, and adding items one by one, it is also possible to populate dictionaries upon their creation using a syntax that makes use of curly brackets. Within this brackets, you need to list all the needed key and value pairs. The keys and the values need to be separated by a colon. All individual items in the dictionary (i.e. the full key and value pairs) need to separated by a comma. The example below offers an example."
+    "## Another way of creating dictionaries\n",
+    "\n",
+    "Instead of starting with an empty dictionary, and adding items one by one, it is also possible to populate dictionaries upon their creation using a syntax that makes use of curly brackets.\n",
+    "Within these brackets, you need to list all the needed key and value pairs.\n",
+    "The keys and the values need to be separated by a colon.\n",
+    "All individual items in the dictionary (i.e. the full key and value pairs) need to separated by commas.\n",
+    "\n",
+    "Let's create a dictionary of countries and their capitals."
    ]
   },
   {
@@ -68,13 +130,13 @@
    "outputs": [],
    "source": [
     "capitals = { \n",
-    "    'France':'Paris', \n",
-    "    'Spain':'Madrid',\n",
-    "    'The Netherlands' : 'Amsterdam' , \n",
-    "    'Belgium':'Brussel' , \n",
-    "    'Italy':'Rome',\n",
-    "    'Germany':'Berlin',\n",
-    "    'Denmark':'Copenhagen'\n",
+    "    'France': 'Paris', \n",
+    "    'Spain': 'Madrid',\n",
+    "    'The Netherlands' : 'Amsterdam', \n",
+    "    'Belgium': 'Brussels',\n",
+    "    'Italy': 'Rome',\n",
+    "    'Germany': 'Berlin',\n",
+    "    'Denmark': 'Copenhagen'\n",
     "} "
    ]
   },
@@ -84,7 +146,9 @@
    "source": [
     "## Navigating a dictionary\n",
     "\n",
-    "As is the case for lists, you can list all the elements in a dictionary via the `for` keyword. "
+    "You can list all the elements in a dictionary via the `for` keyword.\n",
+    "When you *iterate over a dictionary*, you get its *keys*, one at a time.\n",
+    "You can then use that key to look up its value."
    ]
   },
   {
@@ -93,7 +157,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for country in sorted(capitals):\n",
+    "# Our dictionary has the country as the key, so we name our loop variable 'country'\n",
+    "for country in capitals:\n",
     "    print( f'The capital of {country} is {capitals[country]}.' )"
    ]
   },
@@ -105,7 +170,8 @@
     "\n",
     "By default, all the items in this dictionary are shown in the order in which they were added to the dictionary.  \n",
     "\n",
-    "When you have created a dictionary named `capitals`, using the code above, it can be sorted by index using the in-built `sorted()` function. Strings are sorted alphabetically and integers and floats are sorted numerically. "
+    "When you have created a dictionary named `capitals`, using the code above, it can be sorted by index using the in-built `sorted()` function.\n",
+    "Strings are sorted alphabetically and integers and floats are sorted numerically. "
    ]
   },
   {
@@ -116,6 +182,13 @@
    "source": [
     "for country in sorted(capitals):\n",
     "    print( f'The capital of {country} is {capitals[country]}.' )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is also possible to sort a dictionary by its values, but that is outside the scope of this tutorial."
    ]
   },
   {
@@ -131,24 +204,7 @@
    "source": [
     "## Exercise 6.1.\n",
     "\n",
-    "The code below creates a new dictionary. This dictionary connects a number of ISBNs to the titles of the books they identify.\n",
-    "\n",
-    "```\n",
-    "isbn = {\n",
-    "9780143105985 : 'White Noise' ,\n",
-    "9780241984536 : 'Libra' ,\n",
-    "9781925480665 : 'Mao II' ,\n",
-    "9781447289395 : 'Underworld' ,\n",
-    "9780743595728 : 'The Body Artist' ,\n",
-    "9781925480665 : 'Cosmopolis' ,\n",
-    "9780330524919 : 'Falling man' ,\n",
-    "9781439169971 : 'Point Omega'\n",
-    "}\n",
-    "```\n",
-    "\n",
-    "* Add the novel Zero K to the dictionary. This novel has ISBN13 9781501138072.\n",
-    "* Write some code which can print the title that corresponds to ISBN 9781447289395. \n",
-    "* Print a list of all the novels. Display both the ISBN and the title. "
+    "The code below creates a new dictionary. This dictionary connects a number of ISBNs to the titles of the books they identify."
    ]
   },
   {
@@ -158,37 +214,24 @@
    "outputs": [],
    "source": [
     "# Create the dictionary\n",
-    "isbn = {\n",
-    "}\n",
-    "\n",
-    "# Add the novel\n",
-    "\n",
-    "\n",
-    "# Print the title of the book with the ISBN 9781447289395\n",
-    "\n",
-    "\n",
-    "# Print all ISBNs and titles\n"
+    "books_by_isbn = {\n",
+    "    9780143105985 : 'White Noise',\n",
+    "    9780241984536 : 'Libra',\n",
+    "    9781925480665 : 'Mao II',\n",
+    "    9781447289395 : 'Underworld',\n",
+    "    9780743595728 : 'The Body Artist',\n",
+    "    9781925480665 : 'Cosmopolis',\n",
+    "    9780330524919 : 'Falling man',\n",
+    "    9781439169971 : 'Point Omega'\n",
+    "}"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Exercise 6.2.\n",
     "\n",
-    "Using the dictionary `data` below, print the following sentence: “Louis Elsevier was a printer. He was born in 1540 in Leuven and died in 1617 in Leiden.”\n",
-    "\n",
-    "```\n",
-    "data = dict()\n",
-    "\n",
-    "data[\"firstName\"] = 'louis'\n",
-    "data[\"lastName\"] = 'elsevier'\n",
-    "data[\"profession\"] = 'printer'\n",
-    "data[\"yob\"] = 1540\n",
-    "data[\"yod\"] = 1617\n",
-    "data[\"pob\"] = 'leuven'\n",
-    "data[\"pod\"] = 'leiden'\n",
-    "```"
+    "Add the novel Zero K to the dictionary. This novel has ISBN13 9781501138072."
    ]
   },
   {
@@ -202,27 +245,65 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Write some code which can print the title that corresponds to ISBN 9781447289395."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print a list of all the novels. Display both the ISBN and the title. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercise 6.2.\n",
+    "\n",
+    "Using the dictionary `person_data` below, print the following sentence: “Louis Elsevier was a printer. He was born in 1540 in Leuven and died in 1617 in Leiden.”"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "person_data = dict()\n",
+    "\n",
+    "person_data[\"firstName\"] = 'louis'\n",
+    "person_data[\"lastName\"] = 'elsevier'\n",
+    "person_data[\"profession\"] = 'printer'\n",
+    "person_data[\"yob\"] = 1540\n",
+    "person_data[\"yod\"] = 1617\n",
+    "person_data[\"pob\"] = 'leuven'\n",
+    "person_data[\"pod\"] = 'leiden'\n",
+    "\n",
+    "# Print the sentence\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Exercise 6.3.\n",
     "\n",
-    "Copy the code below in your code editor. Using the dictionary `eu`, print a sentence which gives information about the current number of countries in the EU. Add some code which can print a list of all the countries of the EU in alphabetical order. Finally, for each country, print the following sentence: \"The capital of [ *country* ] is [ *capital* ].\"  \n",
-    "\n",
-    "```\n",
-    "eu = {\n",
-    "'Italy':'Rome' , 'Luxembourg':'Luxembourg' ,\n",
-    "'Belgium':'Brussels' , 'Denmark':'Copenhagen' ,\n",
-    "'Finland':'Helsinki' , 'France':'Paris' ,\n",
-    "'Slovakia':'Bratislava' , 'Slovenia':'Ljubljana' ,\n",
-    "'Germany':'Berlin' , 'Greece':'Athens' ,\n",
-    "'Ireland':'Dublin' , 'Netherlands':'Amsterdam' ,\n",
-    "'Portugal':'Lisbon' , 'Spain':'Madrid' ,\n",
-    "'Sweden':'Stockholm' ,\n",
-    "'Cyprus':'Nicosia' , 'Lithuania':'Vilnius' , 'Czech\n",
-    "Republic':'Prague' , 'Estonia':'Tallin' ,\n",
-    "'Hungary':'Budapest' , 'Latvia':'Riga' ,\n",
-    "'Malta':'Valetta' , 'Austria':'Vienna' ,\n",
-    "'Poland':'Warsaw' , 'Croatia':'Zagreb'\n",
-    ",'Romania':'Bucharest' , 'Bulgaria':'Sofia' }\n",
-    "```"
+    "We have a dictionary of countries in the European Union and their capitals."
    ]
   },
   {
@@ -232,16 +313,69 @@
    "outputs": [],
    "source": [
     "# Create the dictionary\n",
-    "eu = {\n",
-    "    \n",
-    "}\n",
-    "\n",
-    "# How many countries are in the EU dictionary?\n",
-    "\n",
-    "\n",
-    "# Print the list of countries in alphabetical order\n",
-    "\n",
-    "\n",
+    "eu_capitals = {\n",
+    "    'Italy': 'Rome', 'Luxembourg': 'Luxembourg',\n",
+    "    'Belgium': 'Brussels', 'Denmark': 'Copenhagen',\n",
+    "    'Finland': 'Helsinki', 'France': 'Paris',\n",
+    "    'Slovakia': 'Bratislava', 'Slovenia': 'Ljubljana',\n",
+    "    'Germany': 'Berlin', 'Greece': 'Athens',\n",
+    "    'Ireland': 'Dublin', 'Netherlands': 'Amsterdam',\n",
+    "    'Portugal': 'Lisbon', 'Spain': 'Madrid',\n",
+    "    'Sweden': 'Stockholm',\n",
+    "    'Cyprus': 'Nicosia', 'Lithuania': 'Vilnius', \n",
+    "    'Czech Republic': 'Prague', 'Estonia': 'Tallin',\n",
+    "    'Hungary': 'Budapest', 'Latvia': 'Riga',\n",
+    "    'Malta': 'Valetta', 'Austria': 'Vienna',\n",
+    "    'Poland': 'Warsaw', 'Croatia': 'Zagreb',\n",
+    "    'Romania': 'Bucharest', 'Bulgaria': 'Sofia'\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using this dictionary, print a sentence which gives information about the current number of countries in the EU."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# How many countries are in the EU dictionary?\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print a list of all the countries of the EU in alphabetical order."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print the list of countries in alphabetical order\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, for each country, print the following sentence: \"The capital of [ *country* ] is [ *capital* ].\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Print the capitals of these countries\n"
    ]
   }

--- a/notebooks/Solutions/6 Dictionaries.ipynb
+++ b/notebooks/Solutions/6 Dictionaries.ipynb
@@ -39,45 +39,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "isbn = {\n",
-    "9780143105985 : 'White Noise' ,\n",
-    "9780241984536 : 'Libra' ,\n",
-    "9781925480665 : 'Mao II' ,\n",
-    "9781447289395 : 'Underworld' ,\n",
-    "9780743595728 : 'The Body Artist' ,\n",
-    "9781925480665 : 'Cosmopolis' ,\n",
-    "9780330524919 : 'Falling man' ,\n",
-    "9781439169971 : 'Point Omega'\n",
-    "}\n",
-    "\n",
-    "isbn[9781501138072] = 'Zero K'\n",
-    "\n",
-    "index = 9781447289395\n",
-    "print( f\"\\nThe ISBN of the novel '{isbn[index] }' is {index}.\\n\" )\n",
-    "\n",
-    "for novel in isbn:\n",
-    "    print( isbn[novel] + ' (' + str(novel) + ')' )"
+    "# Create the dictionary\n",
+    "books_by_isbn = {\n",
+    "    9780143105985 : 'White Noise',\n",
+    "    9780241984536 : 'Libra',\n",
+    "    9781925480665 : 'Mao II',\n",
+    "    9781447289395 : 'Underworld',\n",
+    "    9780743595728 : 'The Body Artist',\n",
+    "    9781925480665 : 'Cosmopolis',\n",
+    "    9780330524919 : 'Falling man',\n",
+    "    9781439169971 : 'Point Omega'\n",
+    "}"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Exercise 6.2.\n",
     "\n",
-    "Using the dictionary `data` below, print the following sentence: “Louis Elsevier was a printer. He was born in 1540 in Leuven and died in 1617 in Leiden.”\n",
-    "\n",
-    "```\n",
-    "data = dict()\n",
-    "\n",
-    "data[\"firstName\"] = 'louis'\n",
-    "data[\"lastName\"] = 'elsevier'\n",
-    "data[\"profession\"] = 'printer'\n",
-    "data[\"yob\"] = 1540\n",
-    "data[\"yod\"] = 1617\n",
-    "data[\"pob\"] = 'leuven'\n",
-    "data[\"pod\"] = 'leiden'\n",
-    "```"
+    "Add the novel Zero K to the dictionary. This novel has ISBN 9781501138072."
    ]
   },
   {
@@ -87,20 +67,91 @@
    "outputs": [],
    "source": [
     "\n",
-    "data = dict()\n",
+    "books_by_isbn[9781501138072] = 'Zero K'\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write some code which can print the title that corresponds to ISBN 9781447289395."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "index = 9781447289395\n",
+    "print( f\"\\nThe ISBN of the novel '{books_by_isbn[index] }' is {index}.\\n\" )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print a list of all the novels. Display both the ISBN and the title. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for isbn in books_by_isbn:\n",
+    "    print( books_by_isbn[isbn] + ' (' + str(isbn) + ')' )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercise 6.2.\n",
     "\n",
-    "data[\"firstName\"] = 'louis'\n",
-    "data[\"lastName\"] = 'elsevier'\n",
-    "data[\"profession\"] = 'printer'\n",
-    "data[\"yob\"] = 1540\n",
-    "data[\"yod\"] = 1617\n",
-    "data[\"pob\"] = 'leuven'\n",
-    "data[\"pod\"] = 'leiden'\n",
+    "Using the dictionary `person_data` below, print the following sentence: “Louis Elsevier was a printer. He was born in 1540 in Leuven and died in 1617 in Leiden.”"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "\n",
-    "sentence = f\"{ data['firstName'].title() } {data['lastName'].title()} was a {data['profession']}. \"\n",
-    "sentence += f\"He was born in {data['yob']} in {data.get('pob' , '[Unknown]' ).title() }\"\n",
-    "sentence += f\" and died in {data['yod']} in {data.get('pod' , '[Unknown]' ).title()}.\"\n",
+    "person_data = dict()\n",
     "\n",
+    "person_data[\"firstName\"] = 'louis'\n",
+    "person_data[\"lastName\"] = 'elsevier'\n",
+    "person_data[\"profession\"] = 'printer'\n",
+    "person_data[\"yob\"] = 1540\n",
+    "person_data[\"yod\"] = 1617\n",
+    "person_data[\"pob\"] = 'leuven'\n",
+    "person_data[\"pod\"] = 'leiden'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We first construct the sentence, to keep the code a bit more readable.\n",
+    "\n",
+    "Remember that you can use `some_string.title()` to capitalise the first character."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "sentence = f\"{ person_data['firstName'].title() } {person_data['lastName'].title()} was a {person_data['profession']}. \"\n",
+    "sentence += f\"He was born in {person_data['yob']} in {person_data.get('pob' , '[Unknown]' ).title() }\"\n",
+    "sentence += f\" and died in {person_data['yod']} in {person_data.get('pod' , '[Unknown]' ).title()}.\"\n",
+    "\n",
+    "# Print the sentence\n",
     "\n",
     "print( sentence )\n"
    ]
@@ -110,26 +161,8 @@
    "metadata": {},
    "source": [
     "## Exercise 6.3.\n",
-    "Copy the code below in your code editor. Using the dictionary `eu`, print a sentence which gives information about the current number of countries in the EU. Add some code which can print a list of all the countries of the EU in alphabetical order. Finally, for each country, print the following sentence: \"The capital of [ *country* ] is [ *capital* ].\"  \n",
     "\n",
-    "\n",
-    "```\n",
-    "eu = {\n",
-    "'Italy':'Rome' , 'Luxembourg':'Luxembourg' ,\n",
-    "'Belgium':'Brussels' , 'Denmark':'Copenhagen' ,\n",
-    "'Finland':'Helsinki' , 'France':'Paris' ,\n",
-    "'Slovakia':'Bratislava' , 'Slovenia':'Ljubljana' ,\n",
-    "'Germany':'Berlin' , 'Greece':'Athens' ,\n",
-    "'Ireland':'Dublin' , 'Netherlands':'Amsterdam' ,\n",
-    "'Portugal':'Lisbon' , 'Spain':'Madrid' ,\n",
-    "'Sweden':'Stockholm' ,\n",
-    "'Cyprus':'Nicosia' , 'Lithuania':'Vilnius' , 'Czech\n",
-    "Republic':'Prague' , 'Estonia':'Tallin' ,\n",
-    "'Hungary':'Budapest' , 'Latvia':'Riga' ,\n",
-    "'Malta':'Valetta' , 'Austria':'Vienna' ,\n",
-    "'Poland':'Warsaw' , 'Croatia':'Zagreb'\n",
-    ",'Romania':'Bucharest' , 'Bulgaria':'Sofia' }\n",
-    "```"
+    "We have a dictionary of countries in the European Union and their capitals."
    ]
   },
   {
@@ -138,23 +171,30 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "eu = {\n",
-    "'Italy':'Rome' , 'Luxembourg':'Luxembourg' , 'Belgium':'Brussels' , 'Denmark':'Copenhagen' , 'Finland':'Helsinki' , 'France':'Paris' , 'Slovakia':'Bratislava' , 'Slovenia':'Ljubljana' , 'Germany':'Berlin' , 'Greece':'Athens' , 'Ireland':'Dublin' , 'Netherlands':'Amsterdam' , 'Portugal':'Lisbon' , 'Spain':'Madrid' , 'Sweden':'Stockholm' , 'United Kingdom':'London' , 'Cyprus':'Nicosia' , 'Lithuania':'Vilnius' , 'Czech Republic':'Prague' , 'Estonia':'Tallin' , 'Hungary':'Budapest' , 'Latvia':'Riga' , 'Malta':'Valetta' , 'Austria':'Vienna' , 'Poland':'Warsaw' , 'Croatia':'Zagreb' ,'Romania':'Bucharest' , 'Bulgaria':'Sofia' }\n",
-    "\n",
-    "print( 'The EU currently has {} member countries:'.format( len(eu) ) )\n",
-    "\n",
-    "\n",
-    "for country in sorted(eu):\n",
-    "    print( country )\n",
-    "\n",
-    "    \n",
-    "\n",
-    "print('\\n-----------\\n')\n",
-    "\n",
-    "\n",
-    "\n",
-    "for country in sorted(eu):\n",
-    "    print( f'The capital of {country} is {eu[country]}.' )\n"
+    "# Create the dictionary\n",
+    "eu_capitals = {\n",
+    "    'Italy': 'Rome', 'Luxembourg': 'Luxembourg',\n",
+    "    'Belgium': 'Brussels', 'Denmark': 'Copenhagen',\n",
+    "    'Finland': 'Helsinki', 'France': 'Paris',\n",
+    "    'Slovakia': 'Bratislava', 'Slovenia': 'Ljubljana',\n",
+    "    'Germany': 'Berlin', 'Greece': 'Athens',\n",
+    "    'Ireland': 'Dublin', 'Netherlands': 'Amsterdam',\n",
+    "    'Portugal': 'Lisbon', 'Spain': 'Madrid',\n",
+    "    'Sweden': 'Stockholm',\n",
+    "    'Cyprus': 'Nicosia', 'Lithuania': 'Vilnius', \n",
+    "    'Czech Republic': 'Prague', 'Estonia': 'Tallin',\n",
+    "    'Hungary': 'Budapest', 'Latvia': 'Riga',\n",
+    "    'Malta': 'Valetta', 'Austria': 'Vienna',\n",
+    "    'Poland': 'Warsaw', 'Croatia': 'Zagreb',\n",
+    "    'Romania': 'Bucharest', 'Bulgaria': 'Sofia'\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using this dictionary, print a sentence which gives information about the current number of countries in the EU."
    ]
   },
   {
@@ -162,12 +202,49 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "print( f'The EU currently has {len(eu_capitals)} member countries:' )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print a list of all the countries of the EU in alphabetical order."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The keys of the dictionary are the countries\n",
+    "for country in sorted(eu_capitals):\n",
+    "    print( country )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, for each country, print the following sentence: \"The capital of [ *country* ] is [ *capital* ].\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for country in sorted(eu_capitals):\n",
+    "    print( f'The capital of {country} is {eu_capitals[country]}.' )"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.10.6 64-bit",
    "language": "python",
    "name": "python3"
   },
@@ -181,7 +258,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.10.6"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "b0fa6594d8f4cbf19f97940f81e996739fb7646882a419484c72d19e05852a7e"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR targets section 6 on Dictionaries. I tried to:

- improve consistency in the use of "key" in dicts vs "index" in lists
- use more Pythonic key names and more descriptive variable names
- split code examples and exercises into several cells
- provide initial code in the code cell, to limit required copy-pasting
- add comments to solutions
- reduce line lengths in Markdown cells