### PR TITLE
Add alternate solution using 'and' for ex 4.2.

### DIFF
--- a/notebooks/Solutions/4 Flow_control.ipynb
+++ b/notebooks/Solutions/4 Flow_control.ipynb
@@ -47,6 +47,39 @@
     "\n",
     "print( f\"It is now {hour} o'clock\" )\n",
     "\n",
+    "# We check for two conditions at once using `and`\n",
+    "if 6 <= hour and hour < 12:\n",
+    "    print(\"Good morning!\")\n",
+    "elif 12 <= hour and hour < 17:\n",
+    "    print(\"Good afternoon!\")\n",
+    "elif 17 <= hour and hour < 23:\n",
+    "    print(\"Good evening!\")\n",
+    "else:\n",
+    "    print(\"Good night!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that we expect the value of `hour` to be reasonable for our code to work as expected.\n",
+    "For example, we don't check whether `hour` is at least 0 or at most 23.\n",
+    "It is advisable to include these checks in code that you rely on.\n",
+    "\n",
+    "In case you wondered if you can make the comparisons more compact, you can!\n",
+    "You can compare a number to two numbers at the same time, as demonstrated below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hour = 19\n",
+    "\n",
+    "print( f\"It is now {hour} o'clock\" )\n",
+    "\n",
     "# You can check a variable against two values at once\n",
     "if 6 <= hour < 12:\n",
     "    print(\"Good morning!\")\n",
@@ -148,7 +181,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.10.6 64-bit",
    "language": "python",
    "name": "python3"
   },
@@ -162,7 +195,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.6"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "b0fa6594d8f4cbf19f97940f81e996739fb7646882a419484c72d19e05852a7e"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes #24 by adding the same solution with explicit combined comparisons, connected using `and`.