### PR TITLE
Update GitHub Workflows' efficiency and syntax

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -11,11 +11,11 @@ jobs:
   deploy-book:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # Install dependencies
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: 3.8
 
@@ -30,7 +30,7 @@ jobs:
 
     # Push the book's HTML to github-pages
     - name: GitHub Pages action
-      uses: peaceiris/actions-gh-pages@v3.6.1
+      uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./_build/html
@@ -38,7 +38,7 @@ jobs:
   zip-notebooks:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Zip notebooks
       run: |
         zip -r notebooks.zip notebooks

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -19,6 +19,23 @@ jobs:
       with:
         python-version: 3.8
 
+    - name: Upgrade pip
+      run: |
+        # install pip=>20.1 to use "pip cache dir"
+        python3 -m pip install --upgrade pip
+
+    - name: Get pip cache dir
+      id: pip-cache
+      run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+
+    - name: Cache dependencies
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
     - name: Install dependencies
       run: |
         pip install -r requirements.txt

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -61,7 +61,7 @@ jobs:
         zip -r notebooks.zip notebooks
     - name: Create release title
       id: set-title
-      run: echo "::set-output name=title::v$(date +'%Y.%m.%d.%H.%M')"
+      run: echo "title=v$(date +'%Y.%m.%d.%H.%M')" >> "$GITHUB_OUTPUT"
     - uses: "marvinpinto/action-automatic-releases@latest"
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -51,21 +51,3 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./_build/html
-
-  zip-notebooks:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Zip notebooks
-      run: |
-        zip -r notebooks.zip notebooks
-    - name: Create release title
-      id: set-title
-      run: echo "title=v$(date +'%Y.%m.%d.%H.%M')" >> "$GITHUB_OUTPUT"
-    - uses: "marvinpinto/action-automatic-releases@latest"
-      with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "${{ steps.set-title.outputs.title }}"
-        prerelease: false
-        files: |
-          notebooks.zip

--- a/.github/workflows/release-notebooks.yml
+++ b/.github/workflows/release-notebooks.yml
@@ -1,0 +1,29 @@
+name: deploy-book
+
+# Only run this when anything in `notebooks/` changes on the main branch
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - 'notebooks/**'
+
+# This job creates a release from the notebooks with data and solutions
+jobs:
+  zip-notebooks:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Zip notebooks
+      run: |
+        zip -r notebooks.zip notebooks
+    - name: Create release title
+      id: set-title
+      run: echo "title=v$(date +'%Y.%m.%d.%H.%M')" >> "$GITHUB_OUTPUT"
+    - uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        automatic_release_tag: "${{ steps.set-title.outputs.title }}"
+        prerelease: false
+        files: |
+          notebooks.zip


### PR DESCRIPTION
This PR should reduce the build time by caching pip dependencies between builds.
It should also reduce the number of releases created by only creating a release when the `notebooks` folder contents change.