### PR TITLE
Clarify functions without parentheses

### DIFF
--- a/notebooks/7 Functions_modules_and_libraries.ipynb
+++ b/notebooks/7 Functions_modules_and_libraries.ipynb
@@ -62,20 +62,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[]"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Returns an empty list\n",
     "list()"
@@ -83,20 +72,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{}"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Returns an empty dictionary\n",
     "dict()"
@@ -106,35 +84,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you don't include the parentheses, you don't call the function, but get it as a value.\n",
-    "This is often not what you want."
+    "Remember: **always include the parentheses when you call a function**.\n",
+    "\n",
+    "If you don't include the parentheses, you don't call the function, you only refer to it.\n",
+    "There are use cases for this behaviour, although few of these use cases are relevant for beginners.\n",
+    "The most useful example is using the `help` function: you *call* the `help` function and \"give it\" a function that you want help with."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<function print>"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Returns the function, but does not *call* it\n",
-    "print"
+    "dict"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# \"Give\" the print function to the help function\n",
+    "help(dict)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "\"Giving\" things to functions is the topic of this next section.\n",
+    "\n",
     "### Parameters and arguments\n",
     "\n",
     "When a function accepts an input, it is said to have a *parameter*.\n",
@@ -354,7 +336,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -593,7 +575,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.9.7"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
Stress that you need `()` to call a function, show when not to use `()` with functions. This (I think) fixes #61.

Reset cell outputs in notebook 7.